### PR TITLE
Projection bounds from db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ config/pg_tileserv*.toml
 server.crt
 server.key
 hugo/.hugo_build.lock
+.env

--- a/Makefile
+++ b/Makefile
@@ -10,25 +10,29 @@
 ##      TARGETARCH - The architecture the resulting image is based on and the binary is compiled for
 ##      IMAGE_TAG - The tag to be applied to the container
 
+-include .env
 APPVERSION ?= latest
-GOVERSION ?= 1.21.6
+GOVERSION ?= 1.22.0
 PROGRAM ?= pg_tileserv
 CONFIG ?= config/$(PROGRAM).toml
-CONTAINER ?= harbor.internal.millcrest.dev/library/$(PROGRAM)
+CONTAINER ?= pramsey/$(PROGRAM)
 DATE ?= $(shell date +%Y%m%d)
 BASE_REGISTRY ?= registry.access.redhat.com
 BASE_IMAGE ?= ubi8-micro
-SYSTEMARCH = $(shell uname -i)
 
-# ifeq ($(SYSTEMARCH), x86_64)
-# TARGETARCH ?= amd64
-# PLATFORM=amd64
-# else
-# TARGETARCH ?= arm64
-# PLATFORM=arm64
-# endif
+ifeq ($(shell uname), Linux)
+SYSTEMARCH = $(shell uname -i)
+else
+SYSTEMARCH = $(shell uname -m)
+endif
+
+ifeq ($(SYSTEMARCH), x86_64)
 TARGETARCH ?= amd64
-PLATFORM ?= amd64
+PLATFORM=amd64
+else
+TARGETARCH ?= arm64
+PLATFORM=arm64
+endif
 
 IMAGE_TAG ?= $(APPVERSION)-$(TARGETARCH)
 DATE_TAG ?= $(DATE)-$(TARGETARCH)

--- a/Makefile
+++ b/Makefile
@@ -14,19 +14,21 @@ APPVERSION ?= latest
 GOVERSION ?= 1.21.6
 PROGRAM ?= pg_tileserv
 CONFIG ?= config/$(PROGRAM).toml
-CONTAINER ?= pramsey/$(PROGRAM)
+CONTAINER ?= harbor.internal.millcrest.dev/library/$(PROGRAM)
 DATE ?= $(shell date +%Y%m%d)
 BASE_REGISTRY ?= registry.access.redhat.com
 BASE_IMAGE ?= ubi8-micro
 SYSTEMARCH = $(shell uname -i)
 
-ifeq ($(SYSTEMARCH), x86_64)
+# ifeq ($(SYSTEMARCH), x86_64)
+# TARGETARCH ?= amd64
+# PLATFORM=amd64
+# else
+# TARGETARCH ?= arm64
+# PLATFORM=arm64
+# endif
 TARGETARCH ?= amd64
-PLATFORM=amd64
-else
-TARGETARCH ?= arm64
-PLATFORM=arm64
-endif
+PLATFORM ?= amd64
 
 IMAGE_TAG ?= $(APPVERSION)-$(TARGETARCH)
 DATE_TAG ?= $(DATE)-$(TARGETARCH)
@@ -83,6 +85,9 @@ build-common: Dockerfile
 		--label os.version="7.7" \
 		-t $(CONTAINER):$(IMAGE_TAG) -t $(CONTAINER):$(DATE_TAG) .
 	docker image prune --filter label=stage=tileservbuilder -f
+
+push-docker:
+	docker push ${CONTAINER}:${IMAGE_TAG}
 
 set-local:
 	$(eval BUILDTYPE = local)

--- a/config/pg_tileserv.toml.example
+++ b/config/pg_tileserv.toml.example
@@ -71,6 +71,9 @@
 # Metrics will be exported at `/metrics`.
 # EnableMetrics = false
 
+# Table in the database that contains projections with bounds (must have columns: srid, x_min, y_min, x_max, y_max)
+# ProjectionBoundsTableName = "common.projection"
+
 # Default CS is Web Mercator (EPSG:3857)
 # DefaultCoordinateSystem = 3857
 # [CoordinateSystem.3857]

--- a/db.go
+++ b/db.go
@@ -23,48 +23,49 @@ import (
 )
 
 func dbConnect() (*pgxpool.Pool, error) {
-	if globalDb == nil {
-		var err error
-		var config *pgxpool.Config
-		dbConnection := viper.GetString("DbConnection")
-		config, err = pgxpool.ParseConfig(dbConnection)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Read and parse connection lifetime
-		dbPoolMaxLifeTime, errt := time.ParseDuration(viper.GetString("DbPoolMaxConnLifeTime"))
-		if errt != nil {
-			log.Fatal(errt)
-		}
-		config.MaxConnLifetime = dbPoolMaxLifeTime
-
-		// Read and parse max connections
-		dbPoolMaxConns := viper.GetInt32("DbPoolMaxConns")
-		if dbPoolMaxConns > 0 {
-			config.MaxConns = dbPoolMaxConns
-		}
-
-		// Read current log level and use one less-fine level
-		// below that
-		config.ConnConfig.Logger = logrusadapter.NewLogger(log.New())
-		levelString, _ := (log.GetLevel() - 1).MarshalText()
-		pgxLevel, _ := pgx.LogLevelFromString(string(levelString))
-		config.ConnConfig.LogLevel = pgxLevel
-
-		// Connect!
-		globalDb, err = pgxpool.ConnectConfig(context.Background(), config)
-		if err != nil {
-			log.Fatal(err)
-		}
-		dbName := config.ConnConfig.Config.Database
-		dbUser := config.ConnConfig.Config.User
-		dbHost := config.ConnConfig.Config.Host
-		log.Infof("Connected as '%s' to '%s' @ '%s'", dbUser, dbName, dbHost)
-
-		return globalDb, err
+	if globalDb != nil {
+		return globalDb, nil
 	}
-	return globalDb, nil
+
+	var err error
+	var config *pgxpool.Config
+	dbConnection := viper.GetString("DbConnection")
+	config, err = pgxpool.ParseConfig(dbConnection)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Read and parse connection lifetime
+	dbPoolMaxLifeTime, errt := time.ParseDuration(viper.GetString("DbPoolMaxConnLifeTime"))
+	if errt != nil {
+		log.Fatal(errt)
+	}
+	config.MaxConnLifetime = dbPoolMaxLifeTime
+
+	// Read and parse max connections
+	dbPoolMaxConns := viper.GetInt32("DbPoolMaxConns")
+	if dbPoolMaxConns > 0 {
+		config.MaxConns = dbPoolMaxConns
+	}
+
+	// Read current log level and use one less-fine level
+	// below that
+	config.ConnConfig.Logger = logrusadapter.NewLogger(log.New())
+	levelString, _ := (log.GetLevel() - 1).MarshalText()
+	pgxLevel, _ := pgx.LogLevelFromString(string(levelString))
+	config.ConnConfig.LogLevel = pgxLevel
+
+	// Connect!
+	globalDb, err = pgxpool.ConnectConfig(context.Background(), config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	dbName := config.ConnConfig.Config.Database
+	dbUser := config.ConnConfig.Config.User
+	dbHost := config.ConnConfig.Config.Host
+	log.Infof("Connected as '%s' to '%s' @ '%s'", dbUser, dbName, dbHost)
+
+	return globalDb, err
 }
 
 func loadVersions() error {
@@ -134,4 +135,28 @@ func dBTileRequest(ctx context.Context, tr *TileRequest) ([]byte, error) {
 
 	}
 	return mvtTile, nil
+}
+
+func dBProjectionBoundsRequest(ctx context.Context, srid int) (float64, float64, float64, float64, error) {
+	db, err := dbConnect()
+	if err != nil {
+		log.Error(err)
+		return 0, 0, 0, 0, err
+	}
+	boundsSQL := fmt.Sprintf(
+		"SELECT x_min, y_min, x_max, y_max FROM %s WHERE srid = $1",
+		globalProjectionBoundsTableName,
+	)
+	row := db.QueryRow(ctx, boundsSQL, srid)
+
+	var (
+		xmin, ymin, xmax, ymax float64
+	)
+	err = row.Scan(&xmin, &ymin, &xmax, &ymax)
+	if err != nil {
+		log.Warn(err)
+		return 0, 0, 0, 0, fmt.Errorf("failed to get bounds from database: %w", err)
+
+	}
+	return xmin, ymin, xmax, ymax, nil
 }

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ var globalPostGISVersion int
 // which tiles are constructed
 var globalServerBounds = make(map[int]*Bounds)
 var globalDefaultCoordinateSystem int
+var globalProjectionBoundsTableName string
 
 // timeToLive is the Cache-Control timeout value that will be advertised
 // in the response headers
@@ -197,6 +198,8 @@ func main() {
 
 	globalDefaultCoordinateSystem = viper.GetInt("DefaultCoordinateSystem")
 	log.Infof("Default CoordinateSystem: %d", globalDefaultCoordinateSystem)
+
+	globalProjectionBoundsTableName = viper.GetString("ProjectionBoundsTableName")
 
 	// Load the global layer list right away
 	// Also connects to database


### PR DESCRIPTION
Coordinate system bounds can now be fetched from the database. For example from the table `common.projection` which has the following columns: `srid, x_min, y_min, x_max, y_max`